### PR TITLE
fix: use bash interpreter for Terraform provisioners

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -34,34 +34,8 @@ resource "null_resource" "process_markdown" {
 
   provisioner "local-exec" {
     working_dir = "${path.module}/.."
-    command = <<-SCRIPT
-set -e
-
-# Check if Node.js is available
-if ! command -v node >/dev/null 2>&1; then
-  echo "Installing Node.js..."
-  curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
-  sudo apt-get install -y nodejs
-else
-  echo "Node.js already installed: $(node --version)"
-fi
-
-# Check if npm is available
-if ! command -v npm >/dev/null 2>&1; then
-  echo "npm not found, something went wrong with Node.js installation"
-  exit 1
-fi
-
-# Install dependencies
-echo "Installing npm dependencies..."
-npm ci
-
-# Process markdown files
-echo "Processing markdown files..."
-npm run build
-
-echo "✅ Markdown processing complete"
-SCRIPT
+    interpreter = ["/bin/bash", "-c"]
+    command = "set -e && if ! command -v node >/dev/null 2>&1; then echo 'Installing Node.js...' && curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash - && sudo apt-get install -y nodejs; else echo 'Node.js already installed:' $(node --version); fi && if ! command -v npm >/dev/null 2>&1; then echo 'npm not found, something went wrong with Node.js installation' && exit 1; fi && echo 'Installing npm dependencies...' && npm ci && echo 'Processing markdown files...' && npm run build && echo '✅ Markdown processing complete'"
   }
 }
 
@@ -80,28 +54,8 @@ resource "null_resource" "upload_website_files" {
   }
 
   provisioner "local-exec" {
-    command = <<-SCRIPT
-set -e
-
-# Check if Azure CLI is available
-if ! command -v az >/dev/null 2>&1; then
-  echo "Installing Azure CLI..."
-  curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-else
-  echo "Azure CLI already installed: $(az version --query '"azure-cli"' -o tsv)"
-fi
-
-# Upload all files from source directory
-echo "Uploading website files to Azure Storage..."
-az storage blob upload-batch \
-  --account-name ${azurerm_storage_account.sa-website.name} \
-  --account-key ${azurerm_storage_account.sa-website.primary_access_key} \
-  --destination '$web' \
-  --source '${path.module}/../source' \
-  --overwrite
-
-echo "✅ Website files uploaded successfully"
-SCRIPT
+    interpreter = ["/bin/bash", "-c"]
+    command = "set -e && if ! command -v az >/dev/null 2>&1; then echo 'Installing Azure CLI...' && curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash; else echo 'Azure CLI already installed:' $(az version --query '\"azure-cli\"' -o tsv); fi && echo 'Uploading website files to Azure Storage...' && az storage blob upload-batch --account-name ${azurerm_storage_account.sa-website.name} --account-key ${azurerm_storage_account.sa-website.primary_access_key} --destination '\$web' --source '${path.module}/../source' --overwrite && echo '✅ Website files uploaded successfully'"
   }
 
 }


### PR DESCRIPTION
- Add explicit interpreter = ["/bin/bash", "-c"] to provisioners
- Convert multi-line heredoc scripts to single-line commands
- Fixes '/bin/sh: set: Illegal option -' error
- Eliminates Windows line ending issues (\r\n)

This resolves Terraform Cloud provisioner execution failures.